### PR TITLE
KE 12595 detect and skip cycles

### DIFF
--- a/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RelSubset.java
@@ -215,6 +215,9 @@ public class RelSubset extends AbstractRelNode {
   Set<RelSubset> getParentSubsets(VolcanoPlanner planner) {
     final Set<RelSubset> list = new LinkedHashSet<>();
     for (RelNode parent : set.getParentRels()) {
+      if (planner.shouldSkipRel(parent)) {
+        continue;
+      }
       for (RelSubset rel : inputSubsets(parent)) {
         if (rel.set == set && rel.getTraitSet().equals(traitSet)) {
           list.add(planner.getSubset(parent));

--- a/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/RuleQueue.java
@@ -546,18 +546,28 @@ class RuleQueue {
    */
   private void checkDuplicateSubsets(Deque<RelSubset> subsets,
       RelOptRuleOperand operand, RelNode[] rels) {
-    final RelSubset subset = planner.getSubset(rels[operand.ordinalInRule]);
+    final RelNode rel = rels[operand.ordinalInRule];
+    final RelSubset subset = planner.getSubset(rel);
     if (subsets.contains(subset)) {
       throw Util.FoundOne.NULL;
     }
+
+    subsets.push(subset);
+    for (RelNode input: rel.getInputs()) {
+      if (subsets.contains(planner.getSubset(input))) {
+        throw Util.FoundOne.NULL;
+      }
+    }
+
     if (!operand.getChildOperands().isEmpty()) {
       subsets.push(subset);
       for (RelOptRuleOperand childOperand : operand.getChildOperands()) {
         checkDuplicateSubsets(subsets, childOperand, rels);
       }
-      final RelSubset x = subsets.pop();
-      assert x == subset;
     }
+
+    final RelSubset x = subsets.pop();
+    assert x == subset;
   }
 
   /**

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -1833,6 +1833,7 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
   }
 
   /**
+   * Reference to https://issues.apache.org/jira/browse/CALCITE-2223
    * Excludes input {@code RelNode} from use in rules in case it creates cycles in the planning
    * cluster. {@link AbstractConverter} are allowed to form cycles since no rules should use
    * on {@link AbstractConverter} operands.

--- a/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
+++ b/core/src/main/java/org/apache/calcite/plan/volcano/VolcanoPlanner.java
@@ -1339,6 +1339,11 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
   void fireRules(
       RelNode rel,
       boolean deferred) {
+
+    if (shouldSkipRel(rel)) {
+      return;
+    }
+
     for (RelOptRuleOperand operand : classOperands.get(rel.getClass())) {
       if (operand.matches(rel)) {
         final VolcanoRuleCall ruleCall;
@@ -1642,6 +1647,8 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
     final RelMetadataQuery mq = rel.getCluster().getMetadataQuery();
     subset.propagateCostImprovements(this, mq, rel, new HashSet<RelSubset>());
 
+    checkCycles(rel);
+
     return subset;
   }
 
@@ -1823,6 +1830,95 @@ public class VolcanoPlanner extends AbstractRelOptPlanner {
       this.rels = rels;
       this.callId = callId;
     }
+  }
+
+  /**
+   * Excludes input {@code RelNode} from use in rules in case it creates cycles in the planning
+   * cluster. {@link AbstractConverter} are allowed to form cycles since no rules should use
+   * on {@link AbstractConverter} operands.
+   */
+  private void checkCycles(RelNode rel) {
+    if (shouldSkipRel(rel)) {
+      // Save time if the node is already skipped somehow
+      return;
+    }
+    if (rel instanceof AbstractConverter) {
+      // AbstractConverter cycles seem to be harmless
+      return;
+    }
+    if (relCreatesCycle(rel)) {
+      // Cycle detected, so we mark this relation as "not interesting"
+      // It is kept in the tree, however we don't use in for further rules
+      setImportance(rel, 0);
+    }
+  }
+
+  /**
+   * Verifies if adding {@code RelNode rel} to planning cluster (the set of {@code RelNodes})
+   * would create a cycle. In case the relation causes a cycle, it is marked with
+   * {@link #setImportance(RelNode, double)}, so the node does not participate in further rules.
+   * <p>The algorithm is go up the tree and check if we happen to hit the subset of the source node.
+   * It might take {@code O(N)} where {@code N} is the total number of {@code RelNode} relations.
+   */
+  private boolean relCreatesCycle(RelNode rel) {
+    // If a cycle is created, just stop using the relation
+    RelSubset relSubset = getSubset(rel);
+
+    // enum could be used, however variables allow to co-locate use with definition
+    final String inProgress = "in progress";
+    final String done = "done";
+    final String shouldNotReach = "should not reach";
+    Map<RelSubset, String> visitedNodes = new HashMap<>();
+
+    for (RelNode input : rel.getInputs()) {
+      if (input == relSubset) {
+        // Avoid creating queue below for simple self-referencing rel node
+        return true;
+      }
+      assert input instanceof RelSubset
+              : "input of a registered node " + rel + " should be RelSubset. Actual input is " + input;
+      visitedNodes.put((RelSubset) input, shouldNotReach);
+    }
+    visitedNodes.put(relSubset, shouldNotReach);
+
+    // Nested loops below perform walk over parent relations
+    // The idea is to avoid processing the same parent multiple times (via visitedNodes), and
+    // stop as soon as we hit relSubset or a child of the source rel node
+    Deque<RelSubset> queue = new ArrayDeque<>();
+    do {
+      RelSubset next = queue.poll();
+      if (next == null) {
+        // the first execution
+        next = relSubset;
+      } else if (shouldNotReach.equals(visitedNodes.get(next))) {
+        return true;
+      }
+      // subset.getParentRels() verifies that "subset" satisfies one of parent's inputs
+      for (RelNode parent : next.getParentRels()) {
+        if (shouldSkipRel(parent) || parent instanceof AbstractConverter) {
+          continue;
+        }
+        RelSubset parentSubset = getSubset(parent);
+        if (parentSubset == next) {
+          continue;
+        }
+        String status = visitedNodes.get(parentSubset);
+        if (shouldNotReach.equals(status)) {
+          return true;
+        } else if (status == null) {
+          visitedNodes.put(parentSubset, inProgress);
+          queue.add(parentSubset);
+        }
+      }
+      visitedNodes.put(next, done);
+    } while (!queue.isEmpty());
+
+    return false;
+  }
+
+  boolean shouldSkipRel(RelNode rel) {
+    Double importance = relImportances.get(rel);
+    return importance != null && importance == 0.0d;
   }
 }
 


### PR DESCRIPTION
1. skip cycle on popMatch()
2. skip cycle on addRelToSet()
3. skip cycle on importance computation

参考 issue: https://issues.apache.org/jira/browse/CALCITE-2223
copied from https://github.com/apache/calcite/pull/855