### PR TITLE
[CALCITE-2321] A union of CHAR columns of different lengths can now (…

### DIFF
--- a/core/src/main/java/org/apache/calcite/jdbc/Driver.java
+++ b/core/src/main/java/org/apache/calcite/jdbc/Driver.java
@@ -176,6 +176,14 @@ public class Driver extends UnregisteredDriver {
         .newConnection(this, factory, CONNECT_STRING_PREFIX, new Properties(),
             rootSchema, typeFactory);
   }
+
+  /** Creates an internal connection. */
+  CalciteConnection connect(CalciteSchema rootSchema,
+      JavaTypeFactory typeFactory, Properties properties) {
+    return (CalciteConnection) ((CalciteFactory) factory)
+        .newConnection(this, factory, CONNECT_STRING_PREFIX, properties,
+            rootSchema, typeFactory);
+  }
 }
 
 // End Driver.java

--- a/core/src/main/java/org/apache/calcite/rel/type/DelegatingTypeSystem.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/DelegatingTypeSystem.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to you under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.calcite.rel.type;
+
+import org.apache.calcite.sql.type.SqlTypeName;
+
+/** Implementation of {@link org.apache.calcite.rel.type.RelDataTypeSystem}
+ * that sends all methods to an underlying object. */
+public class DelegatingTypeSystem implements RelDataTypeSystem {
+  private final RelDataTypeSystem typeSystem;
+
+  /** Creates a {@code DelegatingTypeSystem}. */
+  protected DelegatingTypeSystem(RelDataTypeSystem typeSystem) {
+    this.typeSystem = typeSystem;
+  }
+
+  public int getMaxScale(SqlTypeName typeName) {
+    return typeSystem.getMaxScale(typeName);
+  }
+
+  public int getDefaultPrecision(SqlTypeName typeName) {
+    return typeSystem.getDefaultPrecision(typeName);
+  }
+
+  public int getMaxPrecision(SqlTypeName typeName) {
+    return typeSystem.getMaxPrecision(typeName);
+  }
+
+  public int getMaxNumericScale() {
+    return typeSystem.getMaxNumericScale();
+  }
+
+  public int getMaxNumericPrecision() {
+    return typeSystem.getMaxNumericPrecision();
+  }
+
+  public String getLiteral(SqlTypeName typeName, boolean isPrefix) {
+    return typeSystem.getLiteral(typeName, isPrefix);
+  }
+
+  public boolean isCaseSensitive(SqlTypeName typeName) {
+    return typeSystem.isCaseSensitive(typeName);
+  }
+
+  public boolean isAutoincrement(SqlTypeName typeName) {
+    return typeSystem.isAutoincrement(typeName);
+  }
+
+  public int getNumTypeRadix(SqlTypeName typeName) {
+    return typeSystem.getNumTypeRadix(typeName);
+  }
+
+  public RelDataType deriveSumType(RelDataTypeFactory typeFactory,
+      RelDataType argumentType) {
+    return typeSystem.deriveSumType(typeFactory, argumentType);
+  }
+
+  public RelDataType deriveAvgAggType(RelDataTypeFactory typeFactory,
+      RelDataType argumentType) {
+    return typeSystem.deriveAvgAggType(typeFactory, argumentType);
+  }
+
+  public RelDataType deriveCovarType(RelDataTypeFactory typeFactory,
+      RelDataType arg0Type, RelDataType arg1Type) {
+    return typeSystem.deriveCovarType(typeFactory, arg0Type, arg1Type);
+  }
+
+  public RelDataType deriveFractionalRankType(RelDataTypeFactory typeFactory) {
+    return typeSystem.deriveFractionalRankType(typeFactory);
+  }
+
+  public RelDataType deriveRankType(RelDataTypeFactory typeFactory) {
+    return typeSystem.deriveRankType(typeFactory);
+  }
+
+  public boolean isSchemaCaseSensitive() {
+    return typeSystem.isSchemaCaseSensitive();
+  }
+
+  public boolean shouldConvertRaggedUnionTypesToVarying() {
+    return typeSystem.shouldConvertRaggedUnionTypesToVarying();
+  }
+}
+
+// End DelegatingTypeSystem.java

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeFactoryImpl.java
@@ -194,7 +194,6 @@ public abstract class RelDataTypeFactoryImpl implements RelDataTypeFactory {
         });
   }
 
-  // implement RelDataTypeFactory
   public RelDataType leastRestrictive(List<RelDataType> types) {
     assert types != null;
     assert types.size() >= 1;

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystem.java
@@ -96,6 +96,10 @@ public interface RelDataTypeSystem {
   /** Whether two record types are considered distinct if their field names
    * are the same but in different cases. */
   boolean isSchemaCaseSensitive();
+
+  /** Whether the least restrictive type of a number of CHAR types of different
+   * lengths should be a VARCHAR type. And similarly BINARY to VARBINARY. */
+  boolean shouldConvertRaggedUnionTypesToVarying();
 }
 
 // End RelDataTypeSystem.java

--- a/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystemImpl.java
+++ b/core/src/main/java/org/apache/calcite/rel/type/RelDataTypeSystemImpl.java
@@ -244,6 +244,10 @@ public abstract class RelDataTypeSystemImpl implements RelDataTypeSystem {
     return true;
   }
 
+  public boolean shouldConvertRaggedUnionTypesToVarying() {
+    return false;
+  }
+
 }
 
 // End RelDataTypeSystemImpl.java

--- a/core/src/main/java/org/apache/calcite/sql/fun/SqlCaseOperator.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/SqlCaseOperator.java
@@ -245,9 +245,7 @@ public class SqlCaseOperator extends SqlOperator {
       nullList.add(elseOp);
     }
 
-    RelDataType ret =
-        callBinding.getTypeFactory().leastRestrictive(
-            argTypes);
+    RelDataType ret = callBinding.getTypeFactory().leastRestrictive(argTypes);
     if (null == ret) {
       throw callBinding.newValidationError(RESOURCE.illegalMixingOfTypes());
     }

--- a/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/type/SqlTypeFactoryImpl.java
@@ -23,7 +23,6 @@ import org.apache.calcite.rel.type.RelDataTypeFamily;
 import org.apache.calcite.rel.type.RelDataTypeSystem;
 import org.apache.calcite.sql.SqlCollation;
 import org.apache.calcite.sql.SqlIntervalQualifier;
-import org.apache.calcite.util.Glossary;
 import org.apache.calcite.util.Util;
 
 import java.nio.charset.Charset;
@@ -315,7 +314,7 @@ public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
 
           SqlTypeName newTypeName = type.getSqlTypeName();
 
-          if (shouldRaggedFixedLengthValueUnionBeVariable()) {
+          if (typeSystem.shouldConvertRaggedUnionTypesToVarying()) {
             if (resultType.getPrecision() != type.getPrecision()) {
               if (newTypeName == SqlTypeName.CHAR) {
                 newTypeName = SqlTypeName.VARCHAR;
@@ -487,21 +486,6 @@ public class SqlTypeFactoryImpl extends RelDataTypeFactoryImpl {
       resultType = createTypeWithNullability(resultType, true);
     }
     return resultType;
-  }
-
-  /**
-   * Controls behavior discussed <a
-   * href="http://sf.net/mailarchive/message.php?msg_id=13337379">here</a>.
-   *
-   * @return false (the default) to provide strict SQL:2003 behavior; true to
-   * provide pragmatic behavior
-   *
-   * @see Glossary#SQL2003 SQL:2003 Part 2 Section 9.3 Syntax Rule 3.a.iii.3
-   */
-  protected boolean shouldRaggedFixedLengthValueUnionBeVariable() {
-    // TODO jvs 30-Nov-2006:  implement SQL-Flagger support
-    // for warning about non-standard usage
-    return false;
   }
 
   private RelDataType createDoublePrecisionType() {

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlAbstractConformance.java
@@ -86,6 +86,10 @@ public abstract class SqlAbstractConformance implements SqlConformance {
   public boolean allowGeometry() {
     return SqlConformanceEnum.DEFAULT.allowGeometry();
   }
+
+  public boolean shouldConvertRaggedUnionTypesToVarying() {
+    return SqlConformanceEnum.DEFAULT.shouldConvertRaggedUnionTypesToVarying();
+  }
 }
 
 // End SqlAbstractConformance.java

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformance.java
@@ -306,6 +306,34 @@ public interface SqlConformance {
    * false otherwise.
    */
   boolean allowGeometry();
+
+  /**
+   * Whether the least restrictive type of a number of CHAR types of different
+   * lengths should be a VARCHAR type. And similarly BINARY to VARBINARY.
+   *
+   * <p>For example, consider the query
+   *
+   * <blockquote><pre>SELECT 'abcde' UNION SELECT 'xyz'</pre></blockquote>
+   *
+   * <p>The input columns have types {@code CHAR(5)} and {@code CHAR(3)}, and
+   * we need a result type that is large enough for both:
+   * <ul>
+   * <li>Under strict SQL:2003 behavior, its column has type {@code CHAR(5)},
+   *     and the value in the second row will have trailing spaces.
+   * <li>With lenient behavior, its column has type {@code VARCHAR(5)}, and the
+   *     values have no trailing spaces.
+   * </ul>
+   *
+   * <p>Among the built-in conformance levels, true in
+   * {@link SqlConformanceEnum#PRAGMATIC_99},
+   * {@link SqlConformanceEnum#PRAGMATIC_2003},
+   * {@link SqlConformanceEnum#MYSQL_5};
+   * {@link SqlConformanceEnum#ORACLE_10};
+   * {@link SqlConformanceEnum#ORACLE_12};
+   * {@link SqlConformanceEnum#SQL_SERVER_2008};
+   * false otherwise.
+   */
+  boolean shouldConvertRaggedUnionTypesToVarying();
 }
 
 // End SqlConformance.java

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlConformanceEnum.java
@@ -239,6 +239,20 @@ public enum SqlConformanceEnum implements SqlConformance {
       return false;
     }
   }
+
+  public boolean shouldConvertRaggedUnionTypesToVarying() {
+    switch (this) {
+    case PRAGMATIC_99:
+    case PRAGMATIC_2003:
+    case MYSQL_5:
+    case ORACLE_10:
+    case ORACLE_12:
+    case SQL_SERVER_2008:
+      return true;
+    default:
+      return false;
+    }
+  }
 }
 
 // End SqlConformanceEnum.java


### PR DESCRIPTION
…based on a conformance setting) yield a VARCHAR column (Hequn Cheng)

The previous behavior was to return a CHAR column whose length is the
longest of the inputs. This remains the default behavior, and the
behavior in strict SQL standard mode. The new SqlConformance method is
shouldConvertRaggedUnionTypesToVarying(). Also added
RelDataTypeSystem.shouldConvertRaggedUnionTypesToVarying().

Close apache/calcite#699

(cherry picked from commit 18bfc278839bfbc7c3bde15116e6edab790707a6)