### PR TITLE
#17307, when conformance=LENIENT, groupby clauses now prefer to search for column name rather than alias name. 

### DIFF
--- a/cassandra/pom.xml
+++ b/cassandra/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <artifactId>calcite-cassandra</artifactId>
   <packaging>jar</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite Cassandra</name>
   <description>Cassandra adapter for Calcite</description>
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <artifactId>calcite-core</artifactId>
   <packaging>jar</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite Core</name>
   <description>Core Calcite APIs and engine.</description>
 

--- a/core/src/main/java/org/apache/calcite/sql/SqlNode.java
+++ b/core/src/main/java/org/apache/calcite/sql/SqlNode.java
@@ -17,6 +17,7 @@
 package org.apache.calcite.sql;
 
 import org.apache.calcite.sql.dialect.AnsiSqlDialect;
+import org.apache.calcite.sql.fun.SqlCase;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.calcite.sql.pretty.SqlPrettyWriter;
 import org.apache.calcite.sql.util.SqlString;
@@ -313,6 +314,46 @@ public abstract class SqlNode implements Cloneable {
       }
     }
     return litmus.succeed();
+  }
+
+  /**
+   * Returns whether there is a underlying column in sqlnode, that is same as the alias.
+   *
+   * @param alias alias
+   * @return
+   */
+  public boolean hasUnderlyingColumnSameAsAlias(String alias) {
+    if (this instanceof SqlBasicCall) {
+      SqlNode[] operands = ((SqlBasicCall) this).getOperands();
+      boolean ret = false;
+      for (int i = 0; i < operands.length; i++) {
+        if (operands[i] != null) {
+          ret = ret || operands[i].hasUnderlyingColumnSameAsAlias(alias);
+        }
+      }
+      return ret;
+    } else if (this instanceof SqlCase) {
+      List<SqlNode> operandList = ((SqlCase) this).getOperandList();
+      boolean ret = false;
+      for (int i = 0; i < operandList.size(); i++) {
+        if (operandList.get(i) != null) {
+          ret = ret || operandList.get(i).hasUnderlyingColumnSameAsAlias(alias);
+        }
+      }
+      return ret;
+    } else if (this instanceof SqlNodeList) {
+      List<SqlNode> list = ((SqlNodeList) this).getList();
+      boolean ret = false;
+      for (int i = 0; i < list.size(); i++) {
+        if (list.get(i) != null) {
+          ret = ret || list.get(i).hasUnderlyingColumnSameAsAlias(alias);
+        }
+      }
+      return ret;
+    } else if (this instanceof SqlIdentifier) {
+      return this.toString().equals(alias);
+    }
+    return false;
   }
 }
 

--- a/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
+++ b/core/src/main/java/org/apache/calcite/sql/validate/SqlValidatorImpl.java
@@ -5738,7 +5738,9 @@ public class SqlValidatorImpl implements SqlValidatorWithHints {
         int n = 0;
         for (SqlNode s : select.getSelectList()) {
           final String alias = SqlValidatorUtil.getAlias(s, -1);
-          if (alias != null && nameMatcher.matches(alias, name)) {
+          if (alias != null && nameMatcher.matches(alias, name)
+              && s instanceof SqlBasicCall
+              && !((SqlBasicCall) s).getOperands()[0].hasUnderlyingColumnSameAsAlias(alias)) {
             expr = s;
             n++;
           }

--- a/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
+++ b/core/src/test/java/org/apache/calcite/test/SqlValidatorTest.java
@@ -7625,7 +7625,7 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
     sql("SELECT DISTINCT deptno, 33 FROM emp HAVING ^deptno^ > 55")
         .fails("Expression 'DEPTNO' is not being grouped");
     // same query under a different conformance finds a different error first
-    sql("SELECT DISTINCT ^deptno^, 33 FROM emp HAVING deptno > 55")
+    sql("SELECT DISTINCT deptno, 33 FROM emp HAVING ^deptno^ > 55")
         .tester(tester.withConformance(SqlConformanceEnum.LENIENT))
         .fails("Expression 'DEPTNO' is not being grouped");
     sql("SELECT DISTINCT 33 FROM emp HAVING ^deptno^ > 55")
@@ -7657,6 +7657,36 @@ public class SqlValidatorTest extends SqlValidatorTestCase {
         + "  select distinct deptno from emp) order by 1");
 
     check("SELECT DISTINCT 5, 10+5, 'string' from emp");
+  }
+
+  @Test public void testGroupByAlias() {
+    //test group by alias, when the underlying column in the expression is the same as the alias
+    sql("select DEPTNO+1 as DEPTNO from emp group by DEPTNO+1")
+        .tester(tester.withConformance(SqlConformanceEnum.LENIENT))
+        .ok();
+
+    //test group by alias, when there is two same expr in select
+    sql("select DEPTNO+1,DEPTNO+1 from emp group by DEPTNO+1")
+        .tester(tester.withConformance(SqlConformanceEnum.LENIENT))
+        .ok();
+
+    //test group by alias, when there is two same expr and same alias in select
+    sql("select DEPTNO+1 as DEPTNO,DEPTNO+1 as DEPTNO from emp group by DEPTNO+1")
+         .tester(tester.withConformance(SqlConformanceEnum.LENIENT))
+         .ok();
+
+    //test group by alias, when there is two different expr and same alias in select
+    sql("select DEPTNO+1 as DEPTNO,DEPTNO+2 as DEPTNO from emp group by DEPTNO+1,DEPTNO+2")
+         .tester(tester.withConformance(SqlConformanceEnum.LENIENT))
+         .ok();
+
+    //test group by alias, when there is two same alias named A as A
+    sql("select DEPTNO,DEPTNO from emp group by DEPTNO")
+         .tester(tester.withConformance(SqlConformanceEnum.LENIENT))
+         .ok();
+    sql("select DEPTNO as DEPTNO,DEPTNO as DEPTNO from emp group by DEPTNO")
+         .tester(tester.withConformance(SqlConformanceEnum.LENIENT))
+         .ok();
   }
 
   @Test public void testSelectWithoutFrom() {

--- a/druid/pom.xml
+++ b/druid/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <artifactId>calcite-druid</artifactId>
   <packaging>jar</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite Druid</name>
   <description>Druid adapter for Calcite</description>
 

--- a/elasticsearch2/pom.xml
+++ b/elasticsearch2/pom.xml
@@ -21,12 +21,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <artifactId>calcite-elasticsearch2</artifactId>
   <packaging>jar</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite Elasticsearch</name>
   <description>Elasticsearch adapter for Calcite</description>
 

--- a/elasticsearch5/pom.xml
+++ b/elasticsearch5/pom.xml
@@ -21,12 +21,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <artifactId>calcite-elasticsearch5</artifactId>
   <packaging>jar</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite Elasticsearch5</name>
   <description>Elasticsearch5 adapter for Calcite</description>
 

--- a/example/csv/pom.xml
+++ b/example/csv/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite-example</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <artifactId>calcite-example-csv</artifactId>
   <packaging>jar</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite Example CSV</name>
   <description>An example Calcite provider that reads CSV files</description>
 

--- a/example/function/pom.xml
+++ b/example/function/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite-example</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <artifactId>calcite-example-function</artifactId>
   <packaging>jar</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite Example Function</name>
   <description>Examples of user-defined Calcite functions</description>
 

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -20,13 +20,13 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <!-- The basics. -->
   <artifactId>calcite-example</artifactId>
   <packaging>pom</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite Examples</name>
   <description>Calcite examples</description>
 

--- a/file/pom.xml
+++ b/file/pom.xml
@@ -19,13 +19,13 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <!-- The basics. -->
   <artifactId>calcite-file</artifactId>
   <packaging>jar</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite File</name>
   <description>Calcite provider that reads files and URIs</description>
 

--- a/geode/pom.xml
+++ b/geode/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <artifactId>calcite-geode</artifactId>
   <packaging>jar</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite Geode</name>
   <description>Geode adapter for Calcite</description>
 

--- a/linq4j/pom.xml
+++ b/linq4j/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <artifactId>calcite-linq4j</artifactId>
   <packaging>jar</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite Linq4j</name>
   <description>Calcite APIs for LINQ (Language-Integrated Query) in Java</description>
 

--- a/mongodb/pom.xml
+++ b/mongodb/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <artifactId>calcite-mongodb</artifactId>
   <packaging>jar</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite MongoDB</name>
   <description>MongoDB adapter for Calcite</description>
 

--- a/pig/pom.xml
+++ b/pig/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <artifactId>calcite-pig</artifactId>
   <packaging>jar</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite Pig</name>
   <description>Pig adapter for Calcite</description>
 

--- a/piglet/pom.xml
+++ b/piglet/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <artifactId>calcite-piglet</artifactId>
   <packaging>jar</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite Piglet</name>
   <description>Pig-like language built on top of Calcite algebra</description>
 

--- a/plus/pom.xml
+++ b/plus/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <artifactId>calcite-plus</artifactId>
   <packaging>jar</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite Plus</name>
   <description>Miscellaneous extras for Calcite</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@ limitations under the License.
   <groupId>org.apache.calcite</groupId>
   <artifactId>calcite</artifactId>
   <packaging>pom</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
 
   <!-- More project information. -->
   <name>Calcite</name>

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <artifactId>calcite-server</artifactId>
   <packaging>jar</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite Server</name>
   <description>Calcite Server</description>
 

--- a/spark/pom.xml
+++ b/spark/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <artifactId>calcite-spark</artifactId>
   <packaging>jar</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite Spark</name>
 
   <properties>

--- a/splunk/pom.xml
+++ b/splunk/pom.xml
@@ -20,12 +20,12 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <artifactId>calcite-splunk</artifactId>
   <packaging>jar</packaging>
-  <version>1.16.0-kylin-3.x-r21</version>
+  <version>1.16.0-kylin-3.x-r22</version>
   <name>Calcite Splunk</name>
   <description>Splunk adapter for Calcite; also a JDBC driver for Splunk</description>
 

--- a/ubenchmark/pom.xml
+++ b/ubenchmark/pom.xml
@@ -20,7 +20,7 @@ limitations under the License.
   <parent>
     <groupId>org.apache.calcite</groupId>
     <artifactId>calcite</artifactId>
-    <version>1.16.0-kylin-3.x-r21</version>
+    <version>1.16.0-kylin-3.x-r22</version>
   </parent>
 
   <properties>


### PR DESCRIPTION
#17307, given conformance=LENIENT, groupby clauses now search for column name first, then alias name. If alias name is same as column name, it will choose column name.